### PR TITLE
UNG-2803 Adding non-strict groups verification

### DIFF
--- a/src/main/resources/application-docker.conf
+++ b/src/main/resources/application-docker.conf
@@ -64,6 +64,8 @@ tokenSystem {
 
   externalStateGetter {
     realmName = ${TOKEN_SVC_TOKEN_EXT_REAL_NAME}
+    strictGroupCheck = false
+    strictGroupCheck = ${?TOKEN_SVC_TOKEN_EXT_STRICT_GROUP_CHECK}
   }
 
 }

--- a/src/main/resources/application.base.conf
+++ b/src/main/resources/application.base.conf
@@ -56,6 +56,7 @@ tokenSystem {
     realmName = "ubirch-default-realm"
     deviceGroupsEndpoint = "https://api.console."${tokenSystem.env}".ubirch.com/ubirch-web-ui/api/v1/auth/deviceGroups"
     tenantGroupsEndpoint = "https://api.console."${tokenSystem.env}".ubirch.com/ubirch-web-ui/api/v1/users/groups"
+    strictGroupCheck = false
   }
 
   keyService {

--- a/src/main/scala/com/ubirch/ConfPaths.scala
+++ b/src/main/scala/com/ubirch/ConfPaths.scala
@@ -49,6 +49,7 @@ object ConfPaths {
     final val DEVICE_GROUPS_ENDPOINT = "tokenSystem.externalStateGetter.deviceGroupsEndpoint"
     final val TENANT_GROUPS_ENDPOINT = "tokenSystem.externalStateGetter.tenantGroupsEndpoint"
     final val REALM_NAME = "tokenSystem.externalStateGetter.realmName"
+    final val STRICT_GROUP_CHECK = "tokenSystem.externalStateGetter.strictGroupCheck"
   }
 
   trait KeyServicePaths {

--- a/src/main/scala/com/ubirch/services/rest/RestService.scala
+++ b/src/main/scala/com/ubirch/services/rest/RestService.scala
@@ -14,10 +14,10 @@ import javax.inject._
 import scala.concurrent.Future
 
 /**
- * Represents the basic component for supporting scalatra
- * @param config the configuration object
- * @param lifecycle the life cycle object
- */
+  * Represents the basic component for supporting scalatra
+  * @param config the configuration object
+  * @param lifecycle the life cycle object
+  */
 class RestService @Inject() (config: Config, lifecycle: Lifecycle) extends LazyLogging {
 
   val serverPort: Int = config.getInt(HttpServerConfPaths.PORT)


### PR DESCRIPTION
Introduces a general configuration that allows the group verification to support the grammar "one of" from a list of groups as opposed to "all of". This allows the validation of groups be valid when at least one group is valid for the in-process device. This is useful as there are devices that are not part of both groups.